### PR TITLE
Resolve a clang-tidy warning. Check if configuration exists in

### DIFF
--- a/artdaq-demo/ArtModules/DemoViewer_module.cc
+++ b/artdaq-demo/ArtModules/DemoViewer_module.cc
@@ -162,8 +162,8 @@ void DemoViewer::beginJob()
 	tmp_argv[0] = new char[100];
 	tmp_argv[1] = new char[100];
 
-	strcpy(tmp_argv[0], "-b");
-	strcpy(tmp_argv[1], "--web=server:8877");
+	strlcpy(tmp_argv[0], "-b", 100);
+	strlcpy(tmp_argv[1], "--web=server:8877", 100);
 
 	_app = new TApplication("DemoViewer", &tmp_argc, tmp_argv);
 

--- a/tools/run_integration_tests.sh
+++ b/tools/run_integration_tests.sh
@@ -53,6 +53,12 @@ function run_simple_test_config() {
 	echo "=============================================="
 
 	configDir=$simple_test_config_dir/$config
+
+    if ! [ -d $configDir ]; then
+        echo "ERROR: Could not find config directory $configDir for config $config" >&2
+        return 4
+    fi
+
 	bootfile="--bootfile $daqinterface_rundir/$bootfile_name"
 	brlist=""
 	brs=


### PR DESCRIPTION
run_integration_tests.sh